### PR TITLE
Implement Docker Volume for Persistent Data

### DIFF
--- a/bot/docker-compose.yml
+++ b/bot/docker-compose.yml
@@ -6,8 +6,12 @@ services:
     env_file:
       - .env
     volumes:
-      - ../Server:/app/Server
+      - ../Server:/app/Server # Minecraft server file persists (Direct volume bind to PC dir)
+      - bot_logs:/app/logs # New volume to store bot logs
     ports:
       - "25565:25565" # Maps container port 25565 to host port 25565
     stdin_open: true
     tty: true
+
+volumes:
+  bot_logs: # This defines a named volume

--- a/bot/src/main/java/com/kmrug/discordbot/Bot.java
+++ b/bot/src/main/java/com/kmrug/discordbot/Bot.java
@@ -1,7 +1,5 @@
 package com.kmrug.discordbot;
 
-import io.github.cdimascio.dotenv.Dotenv;
-
 import java.awt.Color;
 import java.io.BufferedReader;
 import java.io.File;
@@ -23,6 +21,7 @@ import java.util.regex.Pattern;
 
 import com.sun.management.OperatingSystemMXBean;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
@@ -63,7 +62,7 @@ public class Bot extends ListenerAdapter {
 
     JDA jda = JDABuilder.createDefault(token)
         .enableIntents(GatewayIntent.MESSAGE_CONTENT)
-        .setActivity(Activity.watching("An idiot manage minecraft servers"))
+        .setActivity(Activity.playing("Custom minecraft servers"))
         .build()
         .awaitReady();
 


### PR DESCRIPTION
- Configured Docker Volumes to persist Minecraft server files and logs.
- Used a bind mount (../Server:/app/Server) for easy local access.
- Added a named volume (bot_logs:/app/logs) to store bot logs persistently.
- Verified that server files and logs persist after container restarts.
- Future plan: Switch to a named volume for Minecraft server before cloud deployment.